### PR TITLE
Support .bash file suffix by default.

### DIFF
--- a/src/main/java/com/github/sbaudoin/sonar/plugins/shellcheck/settings/ShellCheckSettings.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/shellcheck/settings/ShellCheckSettings.java
@@ -26,7 +26,7 @@ public class ShellCheckSettings {
     public static final String SHELLCHECK_PATH_KEY = "sonar.shellcheck.shellcheck.path";
     public static final String SHELLCHECK_PATH_DEFAULT_VALUE = "";
     public static final String FILE_SUFFIXES_KEY = "sonar.shell.file.suffixes";
-    public static final String FILE_SUFFIXES_DEFAULT_VALUE = ".sh,.ksh";
+    public static final String FILE_SUFFIXES_DEFAULT_VALUE = ".sh,.ksh,.bash";
 
 
     private ShellCheckSettings() {


### PR DESCRIPTION
Support the `.bash` file suffix by default.